### PR TITLE
FAI-1284 FAI-1285 Get training course by id in candidate api returns 404 when not found…

### DIFF
--- a/src/SFA.DAS.CandidateAccount.Api.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
+++ b/src/SFA.DAS.CandidateAccount.Api.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
@@ -29,7 +29,7 @@ public class WhenAddingServicesToTheContainer
     [TestCase(typeof(IApplicationRepository))]
     [TestCase(typeof(IAdditionalQuestionRepository))]
     [TestCase(typeof(IWorkHistoryRepository))]
-    [TestCase(typeof(ITrainingCourseRespository))]
+    [TestCase(typeof(ITrainingCourseRepository))]
     [TestCase(typeof(IQualificationReferenceRepository))]
     [TestCase(typeof(IQualificationRepository))]
     [TestCase(typeof(IAddressRepository))]

--- a/src/SFA.DAS.CandidateAccount.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGet.cs
+++ b/src/SFA.DAS.CandidateAccount.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGet.cs
@@ -41,6 +41,26 @@ public class WhenCallingGet
     }
 
     [Test, MoqAutoData]
+    public async Task Then_If_NotFound_Returned_From_Mediator_Then_NotFound_Is_Returned(
+        Guid applicationId,
+        Guid candidateId,
+        Guid id,
+        [Frozen] Mock<IMediator> mediator,
+        [Greedy] TrainingCoursesController controller)
+    {
+        mediator.Setup(x => x.Send(It.IsAny<GetTrainingCourseItemQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GetTrainingCourseItemQueryResult)null!);
+
+        var actual = await controller.Get(candidateId, applicationId, id) as StatusCodeResult;
+
+        using (new AssertionScope())
+        {
+            actual.Should().NotBeNull();
+            actual?.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+        }
+    }
+
+    [Test, MoqAutoData]
     public async Task Then_If_Exception_Returned_From_Mediator_Then_InternalServerError_Is_Returned(
         Guid applicationId,
         Guid candidateId,

--- a/src/SFA.DAS.CandidateAccount.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.CandidateAccount.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -20,7 +20,7 @@ public static class AddServiceRegistrationExtension
         services.AddScoped<IApplicationRepository, ApplicationRepository>();
         services.AddScoped<ICandidateRepository, CandidateRepository>();
         services.AddScoped<IWorkHistoryRepository, WorkHistoryRepository>();
-        services.AddScoped<ITrainingCourseRespository, TrainingCourseRepository>();
+        services.AddScoped<ITrainingCourseRepository, TrainingCourseRepository>();
         services.AddScoped<IAdditionalQuestionRepository, AdditionalQuestionRepository>();
         services.AddScoped<IQualificationReferenceRepository, QualificationReferenceRepository>();
         services.AddScoped<IQualificationRepository, QualificationRepository>();

--- a/src/SFA.DAS.CandidateAccount.Api/Controllers/TrainingCoursesController.cs
+++ b/src/SFA.DAS.CandidateAccount.Api/Controllers/TrainingCoursesController.cs
@@ -52,6 +52,11 @@ public class TrainingCoursesController(IMediator mediator, ILogger<WorkHistoryCo
                 ApplicationId = applicationId,
                 Id = id
             });
+
+            if (result is null)
+            {
+                return NotFound();
+            }
             return Ok((GetTrainingCourseItemApiResponse)result);
         }
         catch (Exception e)

--- a/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingDeleteTrainingCoursesCommand.cs
+++ b/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingDeleteTrainingCoursesCommand.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.CandidateAccount.Application.UnitTests.TrainingCourses
          Guid candidateId,
          Guid applicationId,
          Guid id,
-         [Frozen] Mock<ITrainingCourseRespository> mockRepository,
+         [Frozen] Mock<ITrainingCourseRepository> mockRepository,
          DeleteTrainingCourseCommandHandler handler)
         {
             // Arrange

--- a/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingGetTrainingCourseItemQuery.cs
+++ b/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingGetTrainingCourseItemQuery.cs
@@ -13,7 +13,7 @@ public class WhenHandlingGetTrainingCourseItemQuery
     public async Task Then_Request_Is_Handled_And_Entity_Returned(
         GetTrainingCourseItemQuery request,
         TrainingCourseEntity entity,
-        [Frozen] Mock<ITrainingCourseRespository> trainingCoursesRepository,
+        [Frozen] Mock<ITrainingCourseRepository> trainingCoursesRepository,
         GetTrainingCourseItemQueryHandler handler)
     {
         trainingCoursesRepository.Setup(x => x.Get(request.ApplicationId, request.CandidateId, request.Id, CancellationToken.None)).ReturnsAsync(entity);

--- a/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingGetTrainingCoursesQuery.cs
+++ b/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingGetTrainingCoursesQuery.cs
@@ -13,7 +13,7 @@ public class WhenHandlingGetTrainingCoursesQuery
     public async Task Then_Request_Is_Handled_And_Entities_Returned(
         GetTrainingCoursesQuery request,
         List<TrainingCourseEntity> entities,
-        [Frozen] Mock<ITrainingCourseRespository> trainingCoursesRepository,
+        [Frozen] Mock<ITrainingCourseRepository> trainingCoursesRepository,
         GetTrainingCoursesQueryHandler handler)
     {
         trainingCoursesRepository.Setup(x => x.GetAll(request.ApplicationId, request.CandidateId, CancellationToken.None)).ReturnsAsync(entities);

--- a/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingUpdateTrainingCourseCommand.cs
+++ b/src/SFA.DAS.CandidateAccount.Application.UnitTests/TrainingCourses/WhenHandlingUpdateTrainingCourseCommand.cs
@@ -1,7 +1,6 @@
 using AutoFixture.NUnit3;
 using FluentAssertions;
 using Moq;
-using SFA.DAS.CandidateAccount.Application.Application.Commands.UpdateTrainingCourse;
 using SFA.DAS.CandidateAccount.Application.Application.Commands.UpsertTrainingCourse;
 using SFA.DAS.CandidateAccount.Data.Application;
 using SFA.DAS.CandidateAccount.Data.TrainingCourse;
@@ -16,7 +15,7 @@ public class WhenHandlingUpdateTrainingCourseCommand
         UpsertTrainingCourseCommand command,
         TrainingCourseEntity trainingCourseEntity,
         ApplicationEntity applicationEntity,
-        [Frozen] Mock<ITrainingCourseRespository> trainingCourseRepository,
+        [Frozen] Mock<ITrainingCourseRepository> trainingCourseRepository,
         [Frozen] Mock<IApplicationRepository> applicationRepository,
         UpsertTrainingCourseCommandHandler handler)
     {
@@ -40,7 +39,7 @@ public class WhenHandlingUpdateTrainingCourseCommand
         UpsertTrainingCourseCommand command,
         TrainingCourseEntity trainingCourseEntity,
         ApplicationEntity applicationEntity,
-        [Frozen] Mock<ITrainingCourseRespository> trainingCourseRepository,
+        [Frozen] Mock<ITrainingCourseRepository> trainingCourseRepository,
         [Frozen] Mock<IApplicationRepository> applicationRepository,
         UpsertTrainingCourseCommandHandler handler)
     {
@@ -64,7 +63,7 @@ public class WhenHandlingUpdateTrainingCourseCommand
         UpsertTrainingCourseCommand command,
         TrainingCourseEntity trainingCourseEntity,
         ApplicationEntity applicationEntity,
-        [Frozen] Mock<ITrainingCourseRespository> trainingCourseRepository,
+        [Frozen] Mock<ITrainingCourseRepository> trainingCourseRepository,
         [Frozen] Mock<IApplicationRepository> applicationRepository,
         UpsertTrainingCourseCommandHandler handler)
     {

--- a/src/SFA.DAS.CandidateAccount.Application/Application/Commands/DeleteTrainingCourse/DeleteTrainingCourseCommandHandler.cs
+++ b/src/SFA.DAS.CandidateAccount.Application/Application/Commands/DeleteTrainingCourse/DeleteTrainingCourseCommandHandler.cs
@@ -4,11 +4,11 @@ using SFA.DAS.CandidateAccount.Data.TrainingCourse;
 
 namespace SFA.DAS.CandidateAccount.Application.Application.Commands.DeleteTrainingCourse
 {
-    public class DeleteTrainingCourseCommandHandler (ITrainingCourseRespository trainingCourseRespository) : IRequestHandler<DeleteTrainingCourseCommand, Unit>
+    public class DeleteTrainingCourseCommandHandler (ITrainingCourseRepository trainingCourseRepository) : IRequestHandler<DeleteTrainingCourseCommand, Unit>
     {
         public async Task<Unit> Handle(DeleteTrainingCourseCommand command, CancellationToken cancellation)
         {
-            await trainingCourseRespository.Delete(command.ApplicationId, command.Id, command.CandidateId);
+            await trainingCourseRepository.Delete(command.ApplicationId, command.Id, command.CandidateId);
 
             return Unit.Value;
 

--- a/src/SFA.DAS.CandidateAccount.Application/Application/Commands/UpsertTrainingCourse/UpsertTrainingCourseCommandHandler.cs
+++ b/src/SFA.DAS.CandidateAccount.Application/Application/Commands/UpsertTrainingCourse/UpsertTrainingCourseCommandHandler.cs
@@ -1,11 +1,10 @@
 using MediatR;
-using SFA.DAS.CandidateAccount.Application.Application.Commands.UpsertTrainingCourse;
 using SFA.DAS.CandidateAccount.Data.Application;
 using SFA.DAS.CandidateAccount.Data.TrainingCourse;
 using SFA.DAS.CandidateAccount.Domain.Application;
 
-namespace SFA.DAS.CandidateAccount.Application.Application.Commands.UpdateTrainingCourse;
-public class UpsertTrainingCourseCommandHandler(ITrainingCourseRespository trainingCourseRepository, IApplicationRepository applicationRepository) 
+namespace SFA.DAS.CandidateAccount.Application.Application.Commands.UpsertTrainingCourse;
+public class UpsertTrainingCourseCommandHandler(ITrainingCourseRepository trainingCourseRepository, IApplicationRepository applicationRepository) 
     : IRequestHandler<UpsertTrainingCourseCommand, UpsertTrainingCourseCommandResponse>
 {
     public async Task<UpsertTrainingCourseCommandResponse> Handle(UpsertTrainingCourseCommand request, CancellationToken cancellationToken)

--- a/src/SFA.DAS.CandidateAccount.Application/Application/Queries/GetTrainingCourseItem/GetTrainingCourseItemQueryHandler.cs
+++ b/src/SFA.DAS.CandidateAccount.Application/Application/Queries/GetTrainingCourseItem/GetTrainingCourseItemQueryHandler.cs
@@ -2,11 +2,11 @@
 using SFA.DAS.CandidateAccount.Data.TrainingCourse;
 
 namespace SFA.DAS.CandidateAccount.Application.Application.Queries.GetTrainingCourseItem;
-public class GetTrainingCourseItemQueryHandler(ITrainingCourseRespository TrainingCourseRespository) : IRequestHandler<GetTrainingCourseItemQuery, GetTrainingCourseItemQueryResult?>
+public class GetTrainingCourseItemQueryHandler(ITrainingCourseRepository trainingCourseRepository) : IRequestHandler<GetTrainingCourseItemQuery, GetTrainingCourseItemQueryResult?>
 {
     public async Task<GetTrainingCourseItemQueryResult?> Handle(GetTrainingCourseItemQuery request, CancellationToken cancellationToken)
     {
-        var result = await TrainingCourseRespository.Get(request.ApplicationId, request.CandidateId, request.Id, cancellationToken);
+        var result = await trainingCourseRepository.Get(request.ApplicationId, request.CandidateId, request.Id, cancellationToken);
         return result == null ? null : (GetTrainingCourseItemQueryResult) result;
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Application/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
+++ b/src/SFA.DAS.CandidateAccount.Application/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
@@ -2,7 +2,7 @@
 using SFA.DAS.CandidateAccount.Data.TrainingCourse;
 
 namespace SFA.DAS.CandidateAccount.Application.Application.Queries.GetTrainingCourses;
-public class GetTrainingCoursesQueryHandler(ITrainingCourseRespository TrainingCourseRespository) : IRequestHandler<GetTrainingCoursesQuery, GetTrainingCoursesQueryResult>
+public class GetTrainingCoursesQueryHandler(ITrainingCourseRepository TrainingCourseRespository) : IRequestHandler<GetTrainingCoursesQuery, GetTrainingCoursesQueryResult>
 {
     public async Task<GetTrainingCoursesQueryResult> Handle(GetTrainingCoursesQuery request, CancellationToken cancellationToken)
     {

--- a/src/SFA.DAS.CandidateAccount.Data.UnitTests/Repository/TrainingCourse/WhenDeletingTrainingCourse.cs
+++ b/src/SFA.DAS.CandidateAccount.Data.UnitTests/Repository/TrainingCourse/WhenDeletingTrainingCourse.cs
@@ -14,17 +14,38 @@ namespace SFA.DAS.CandidateAccount.Data.UnitTests.Repository.TrainingCourse
         public async Task ThenTheJobIsDeleted(
         TrainingCourseEntity trainingCourseEntity,
         [Frozen] Mock<ICandidateAccountDataContext> context,
-        TrainingCourseRepository repository
-        )
+        TrainingCourseRepository repository)
         {
             //Arrange
-            context.Setup(x => x.TrainingCourseEntities).ReturnsDbSet(new List<TrainingCourseEntity>());
+            context.Setup(x => x.TrainingCourseEntities).ReturnsDbSet(new List<TrainingCourseEntity>()
+            {
+                trainingCourseEntity
+            });
 
             //Act
-            await repository.Delete(trainingCourseEntity.ApplicationId, trainingCourseEntity.Id, trainingCourseEntity.ApplicationEntity.Id);
+            await repository.Delete(trainingCourseEntity.ApplicationId, trainingCourseEntity.Id, trainingCourseEntity.ApplicationEntity.CandidateId);
 
             //Assert
             context.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Once);
+        }
+
+        [Test, RecursiveMoqAutoData]
+        public async Task When_TrainingCourse_NotFound_Then_Delete_NotCalled(
+            TrainingCourseEntity trainingCourseEntity,
+            [Frozen] Mock<ICandidateAccountDataContext> context,
+            TrainingCourseRepository repository)
+        {
+            //Arrange
+            context.Setup(x => x.TrainingCourseEntities).ReturnsDbSet(new List<TrainingCourseEntity>
+            {
+                Capacity = 0
+            });
+
+            //Act
+            await repository.Delete(trainingCourseEntity.ApplicationId, trainingCourseEntity.Id, trainingCourseEntity.ApplicationEntity.CandidateId);
+
+            //Assert
+            context.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never);
         }
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Data/TrainingCourse/TrainingCourseRepository.cs
+++ b/src/SFA.DAS.CandidateAccount.Data/TrainingCourse/TrainingCourseRepository.cs
@@ -71,8 +71,11 @@ namespace SFA.DAS.CandidateAccount.Data.TrainingCourse
             .Where(w => w.Id == id && w.ApplicationId == applicationId && w.ApplicationEntity.CandidateId == candidateId)
             .SingleOrDefaultAsync();
 
-            if (trainingCourse != null) dataContext.TrainingCourseEntities.Remove(trainingCourse);
-            await dataContext.SaveChangesAsync();
+            if (trainingCourse != null)
+            {
+                dataContext.TrainingCourseEntities.Remove(trainingCourse);
+                await dataContext.SaveChangesAsync();
+            }
         }
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Data/TrainingCourse/TrainingCourseRepository.cs
+++ b/src/SFA.DAS.CandidateAccount.Data/TrainingCourse/TrainingCourseRepository.cs
@@ -3,7 +3,7 @@ using SFA.DAS.CandidateAccount.Domain.Application;
 
 namespace SFA.DAS.CandidateAccount.Data.TrainingCourse
 {
-    public interface ITrainingCourseRespository
+    public interface ITrainingCourseRepository
     {
         Task<Tuple<TrainingCourseEntity, bool>> UpsertTrainingCourse(Domain.Application.TrainingCourse trainingCourseEntity, Guid candidateId);
         Task<TrainingCourseEntity?> Get(Guid applicationId, Guid candidateId, Guid id, CancellationToken cancellationToken);
@@ -11,7 +11,7 @@ namespace SFA.DAS.CandidateAccount.Data.TrainingCourse
         Task Delete(Guid applicationId, Guid id, Guid candidateId);
     }
 
-    public class TrainingCourseRepository(ICandidateAccountDataContext dataContext) : ITrainingCourseRespository
+    public class TrainingCourseRepository(ICandidateAccountDataContext dataContext) : ITrainingCourseRepository
     {
         public async Task<TrainingCourseEntity?> Get(Guid applicationId, Guid candidateId, Guid id, CancellationToken cancellationToken)
         {
@@ -67,12 +67,11 @@ namespace SFA.DAS.CandidateAccount.Data.TrainingCourse
 
         public async Task Delete(Guid applicationId, Guid id, Guid candidateId)
         {
-
             var trainingCourse = await dataContext.TrainingCourseEntities
             .Where(w => w.Id == id && w.ApplicationId == applicationId && w.ApplicationEntity.CandidateId == candidateId)
             .SingleOrDefaultAsync();
 
-            dataContext.TrainingCourseEntities.Remove(trainingCourse);
+            if (trainingCourse != null) dataContext.TrainingCourseEntities.Remove(trainingCourse);
             await dataContext.SaveChangesAsync();
         }
     }


### PR DESCRIPTION
Get training course by id in candidate api returns 404 when not found + Unit test cases

Candidate API Delete training course when not exists returns 500 instead of OK response

Minor clean-up => Namespace & typos Resolved

Story: https://skillsfundingagency.atlassian.net/browse/FAI-1284