### PR TITLE
DASD-11121 Add dedicated ASP

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
     parameters:
       SolutionBaseName: $(SolutionBaseName)
       DatabaseProjectPath: src/$(SolutionBaseName).Database/$(SolutionBaseName).Database.csproj
-  
+
 - stage: Deploy_AT
   dependsOn: Build
   displayName: Deploy to AT
@@ -118,7 +118,7 @@ stages:
 #   variables:
 #   - group: PROD Management Resources
 #   - group: PROD Shared Resources
-#   - group: __PRODSpecificReleaseVariables__ #PLACEHOLDER
+#   - group: PROD das-candidate-account-api
 #   jobs:
 #   - template: pipeline-templates/job/deploy.yml
 #     parameters:

--- a/azure/template.json
+++ b/azure/template.json
@@ -154,6 +154,27 @@
         },
         {
             "apiVersion": "2021-04-01",
+            "name": "[concat(parameters('subnetObject').name, '-sql-firewall-rule-', parameters('utcValue'))]",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'sql-server-firewall-rules.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "serverName": {
+                        "value": "[parameters('sharedSQLServerName')]"
+                    },
+                    "subnetResourceIdList": {
+                        "value": "[createArray(reference(concat(parameters('subnetObject').name, '-', parameters('utcValue'))).outputs.SubnetResourceId.value)]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2021-04-01",
             "name": "[concat(variables('apiAppServiceName'), '-app-service-plan-', parameters('utcValue'))]",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[parameters('sharedEnvResourceGroup')]",

--- a/azure/template.json
+++ b/azure/template.json
@@ -75,6 +75,30 @@
         "utcValue": {
             "type": "string",
             "defaultValue": "[utcNow()]"
+        },
+        "aspSize": {
+            "type": "string",
+            "defaultValue": "1"
+        },
+        "aspInstances": {
+            "type": "int",
+            "defaultValue": 1
+        },
+        "nonASETier": {
+            "type": "string",
+            "defaultValue": "PremiumV2"
+        },
+        "sharedEnvVirtualNetworkName": {
+            "type": "string"
+        },
+        "subnetObject": {
+            "type": "object"
+        },
+        "subnetServiceEndpointList": {
+            "type": "array"
+        },
+        "subnetDelegations": {
+            "type": "array"
         }
     },
     "variables": {
@@ -83,6 +107,7 @@
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), 'api-rg')]",
         "databaseName": "[concat(variables('resourceNamePrefix'), '-db')]",
         "apiAppServiceName": "[concat(variables('resourceNamePrefix'), 'api-as')]",
+        "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
         "configNames": "SFA.DAS.CandidateAccount.Api"
     },
     "resources": [
@@ -93,6 +118,69 @@
             "location": "[parameters('resourceGroupLocation')]",
             "tags": "[parameters('tags')]",
             "properties": {}
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat(parameters('subnetObject').name, '-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'subnet.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "virtualNetworkName": {
+                        "value": "[parameters('sharedEnvVirtualNetworkName')]"
+                    },
+                    "subnetName": {
+                        "value": "[parameters('subnetObject').name]"
+                    },
+                    "subnetAddressPrefix": {
+                        "value": "[parameters('subnetObject').addressSpace]"
+                    },
+                    "serviceEndpointList": {
+                        "value": "[parameters('subnetServiceEndpointList')]"
+                    },
+                    "delegations": {
+                        "value": "[parameters('subnetDelegations')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat(variables('apiAppServiceName'), '-app-service-plan-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServicePlanName": {
+                        "value": "[variables('appServicePlanName')]"
+                    },
+                    "aspSize": {
+                        "value": "[parameters('aspSize')]"
+                    },
+                    "aspInstances": {
+                        "value": "[parameters('aspInstances')]"
+                    },
+                    "nonASETier": {
+                        "value": "[parameters('nonASETier')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
         },
         {
             "apiVersion": "2021-04-01",
@@ -215,7 +303,8 @@
                 }
             },
             "dependsOn": [
-                "[variables('resourceGroupName')]"
+                "[variables('resourceGroupName')]",
+                "[concat(variables('apiAppServiceName'), '-app-service-plan-', parameters('utcValue'))]"
             ]
         },
         {

--- a/azure/template.json
+++ b/azure/template.json
@@ -107,7 +107,7 @@
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), 'api-rg')]",
         "databaseName": "[concat(variables('resourceNamePrefix'), '-db')]",
         "apiAppServiceName": "[concat(variables('resourceNamePrefix'), 'api-as')]",
-        "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
+        "appServicePlanName": "[concat(variables('resourceNamePrefix'), 'api-asp')]",
         "configNames": "SFA.DAS.CandidateAccount.Api"
     },
     "resources": [

--- a/src/SFA.DAS.CandidateAccount.Api/SFA.DAS.CandidateAccount.Api.csproj
+++ b/src/SFA.DAS.CandidateAccount.Api/SFA.DAS.CandidateAccount.Api.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
-        <PackageReference Include="Azure.Identity" Version="1.11.1" />
+        <PackageReference Include="Azure.Identity" Version="1.11.4" />
         <PackageReference Include="MediatR" Version="12.2.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
         <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.1" />

--- a/src/SFA.DAS.CandidateAccount.Data.UnitTests/SFA.DAS.CandidateAccount.Data.UnitTests.csproj
+++ b/src/SFA.DAS.CandidateAccount.Data.UnitTests/SFA.DAS.CandidateAccount.Data.UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.1" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/src/SFA.DAS.CandidateAccount.Data/SFA.DAS.CandidateAccount.Data.csproj
+++ b/src/SFA.DAS.CandidateAccount.Data/SFA.DAS.CandidateAccount.Data.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.11.1" />
+      <PackageReference Include="Azure.Identity" Version="1.11.4" />
       <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />


### PR DESCRIPTION
**Context**

The API will see increased load when the FAA v2 UI goes live. We should move the API on to it's own ASP for go-live and then hopefully back on to one of the new shared ASP's when they are deployed.

The move has a number of phases.

This PR creates the ASP, subnet and firewall rule for the change.
A script can then be run that disconnects the subnet, moves the app to the new ASP and reconnects to the new subnet
Follow-up PR to align the ARM template to the new structure

**Proposed changes**

Add new ASP resource
Add new subnet resource
Add new subnet firewall rule resource
Fix package vulnerability