### PR TITLE
FAI-1939 Reverted the Unique Constraint from Candidate Email

### DIFF
--- a/src/SFA.DAS.CandidateAccount.Data/Candidate/CandidateRepository.cs
+++ b/src/SFA.DAS.CandidateAccount.Data/Candidate/CandidateRepository.cs
@@ -18,7 +18,9 @@ public class CandidateRepository(ICandidateAccountDataContext dataContext) : ICa
     {
         var existingCandidate = await dataContext
             .CandidateEntities
-            .FirstOrDefaultAsync(c => c.GovUkIdentifier == candidate.GovUkIdentifier);
+            .FirstOrDefaultAsync(c => 
+                c.GovUkIdentifier == candidate.GovUkIdentifier || 
+                c.Email == candidate.Email);
 
         if (existingCandidate != null) return new Tuple<CandidateEntity, bool>(existingCandidate, false);
 

--- a/src/SFA.DAS.CandidateAccount.Data/Candidate/CandidateRepository.cs
+++ b/src/SFA.DAS.CandidateAccount.Data/Candidate/CandidateRepository.cs
@@ -19,8 +19,7 @@ public class CandidateRepository(ICandidateAccountDataContext dataContext) : ICa
         var existingCandidate = await dataContext
             .CandidateEntities
             .FirstOrDefaultAsync(c => 
-                c.GovUkIdentifier == candidate.GovUkIdentifier || 
-                c.Email == candidate.Email);
+                c.GovUkIdentifier == candidate.GovUkIdentifier);
 
         if (existingCandidate != null) return new Tuple<CandidateEntity, bool>(existingCandidate, false);
 

--- a/src/SFA.DAS.CandidateAccount.Database/Tables/Candidate.sql
+++ b/src/SFA.DAS.CandidateAccount.Database/Tables/Candidate.sql
@@ -14,7 +14,7 @@ CREATE TABLE dbo.[Candidate] (
     [MigratedEmail]			varchar(255)	    NULL,
     [MigratedCandidateId]	uniqueidentifier	    NULL,
     CONSTRAINT [PK_Candidate] PRIMARY KEY (Id),
-    CONSTRAINT [UK_Candidate] UNIQUE (GovUkIdentifier, Email),
+    CONSTRAINT [UK_Candidate] UNIQUE (GovUkIdentifier),
     INDEX [IX_Candidate_Email] NONCLUSTERED(Email),
     INDEX [IX_Candidate_MigratedCandidateId] NONCLUSTERED(MigratedCandidateId),
     INDEX [IX_Candidate_GovUkIdentifier] NONCLUSTERED(GovUkIdentifier),


### PR DESCRIPTION
1. Reverted the Unique Constraint from Candidate Email
2. Added the logic to the Candidate Repository Insert method to return existing candidate rather than creating a new one
3. Unit test case added for the new login

Task: https://skillsfundingagency.atlassian.net/browse/FAI-1939