### PR TITLE
FAI-2187 - Remove no longer required communication preference

### DIFF
--- a/src/SFA.DAS.CandidateAccount.Database/Post-Deployment/Script.PostDeployment.sql
+++ b/src/SFA.DAS.CandidateAccount.Database/Post-Deployment/Script.PostDeployment.sql
@@ -53,3 +53,8 @@ ELSE
 BEGIN
     UPDATE Preference set PreferenceHint = 'Get a reminder 7 days before the closing date for an apprenticeship. We''ll notify you for your saved vacancies and apprenticeships you''ve began an application for.', PreferenceType='closing' where PreferenceMeaning = 'A vacancy is closing soon'
 END
+
+IF EXISTS(SELECT 1 FROM Preference where PreferenceMeaning = 'Your application gets a response')
+BEGIN
+    DELETE FROM Preference where PreferenceMeaning = 'Your application gets a response'
+END


### PR DESCRIPTION
Remove preference that is no longer required which is causing an error in production when trying to run the closing soon reminders