### PR TITLE
FAI-2326 Preserve additional questions ordering

### DIFF
--- a/src/SFA.DAS.CandidateAccount.Api.UnitTests/Controllers/Application/WhenCallingPutApplication.cs
+++ b/src/SFA.DAS.CandidateAccount.Api.UnitTests/Controllers/Application/WhenCallingPutApplication.cs
@@ -36,7 +36,7 @@ public class WhenCallingPutApplication
                 && c.IsWorkHistoryComplete.Equals(applicationRequest.IsWorkHistoryComplete)
                 && c.IsAdditionalQuestion1Complete.Equals(applicationRequest.IsAdditionalQuestion1Complete)
                 && c.IsAdditionalQuestion2Complete.Equals(applicationRequest.IsAdditionalQuestion2Complete)
-                && c.AdditionalQuestions.SequenceEqual(applicationRequest.AdditionalQuestions.ToList())
+                && c.AdditionalQuestions.Equals(applicationRequest.AdditionalQuestions)
             ), CancellationToken.None))
             .ReturnsAsync(upsertApplicationCommandResult);
         
@@ -71,7 +71,7 @@ public class WhenCallingPutApplication
                 && c.IsWorkHistoryComplete.Equals(applicationRequest.IsWorkHistoryComplete)
                 && c.IsAdditionalQuestion1Complete.Equals(applicationRequest.IsAdditionalQuestion1Complete)
                 && c.IsAdditionalQuestion2Complete.Equals(applicationRequest.IsAdditionalQuestion2Complete)
-                && c.AdditionalQuestions.SequenceEqual(applicationRequest.AdditionalQuestions.ToList())
+                && c.AdditionalQuestions.Equals(applicationRequest.AdditionalQuestions)
                 ), CancellationToken.None))
             .ReturnsAsync(upsertApplicationCommandResult);
         

--- a/src/SFA.DAS.CandidateAccount.Api/ApiRequests/ApplicationRequest.cs
+++ b/src/SFA.DAS.CandidateAccount.Api/ApiRequests/ApplicationRequest.cs
@@ -17,5 +17,5 @@ public class ApplicationRequest
     public SectionStatus IsWorkHistoryComplete { get; set; }
     public SectionStatus IsAdditionalQuestion1Complete { get; set; }
     public SectionStatus IsAdditionalQuestion2Complete { get; set; }
-    public IEnumerable<string?> AdditionalQuestions { get; set; } = [];
+    public List<KeyValuePair<int, string>>? AdditionalQuestions { get; set; } = [];
 }

--- a/src/SFA.DAS.CandidateAccount.Api/Controllers/ApplicationController.cs
+++ b/src/SFA.DAS.CandidateAccount.Api/Controllers/ApplicationController.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-using System.Net;
 using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
@@ -12,7 +10,8 @@ using SFA.DAS.CandidateAccount.Application.Application.Queries.GetApplication;
 using SFA.DAS.CandidateAccount.Application.Application.Queries.GetApplicationByVacancyReference;
 using SFA.DAS.CandidateAccount.Application.Application.Queries.GetApplications;
 using SFA.DAS.CandidateAccount.Domain.Application;
-using SFA.DAS.CandidateAccount.Domain.Candidate;
+using System.ComponentModel.DataAnnotations;
+using System.Net;
 
 namespace SFA.DAS.CandidateAccount.Api.Controllers;
 
@@ -40,7 +39,7 @@ public class ApplicationController(IMediator mediator, ILogger<ApplicationContro
                 IsWorkHistoryComplete = applicationRequest.IsWorkHistoryComplete,
                 IsAdditionalQuestion1Complete = applicationRequest.IsAdditionalQuestion1Complete,
                 IsAdditionalQuestion2Complete = applicationRequest.IsAdditionalQuestion2Complete,
-                AdditionalQuestions = applicationRequest.AdditionalQuestions.ToList()
+                AdditionalQuestions = applicationRequest.AdditionalQuestions
             });
 
             if (result.IsCreated)
@@ -110,7 +109,7 @@ public class ApplicationController(IMediator mediator, ILogger<ApplicationContro
             }
 
             var getApplicationApiResponse = includeDetail
-                ? (GetApplicationApiResponse)((ApplicationDetail)result.Application)
+                ? (GetApplicationApiResponse)(ApplicationDetail)result.Application
                 : (Domain.Application.Application)result.Application;
             return Ok(getApplicationApiResponse);
         }

--- a/src/SFA.DAS.CandidateAccount.Application.UnitTests/AdditionalQuestion/WhenHandlingGetAdditionalQuestionQueryHandler.cs
+++ b/src/SFA.DAS.CandidateAccount.Application.UnitTests/AdditionalQuestion/WhenHandlingGetAdditionalQuestionQueryHandler.cs
@@ -22,6 +22,9 @@ public class WhenHandlingGetAdditionalQuestionQueryHandler
 
         var actual = await handler.Handle(request, CancellationToken.None);
 
-        actual.Should().BeEquivalentTo(entity, options =>  options.Excluding(c=>c.ApplicationEntity));
+        actual.Should().BeEquivalentTo(entity, options =>  options
+            .Excluding(c=>c.ApplicationEntity)
+            .Excluding(c => c.QuestionOrder)
+        );
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Application/Application/Commands/UpsertApplication/UpsertApplicationCommand.cs
+++ b/src/SFA.DAS.CandidateAccount.Application/Application/Commands/UpsertApplication/UpsertApplicationCommand.cs
@@ -16,5 +16,5 @@ public record UpsertApplicationCommand : IRequest<UpsertApplicationCommandRespon
     public SectionStatus? IsAdditionalQuestion1Complete { get; init; }
     public SectionStatus? IsAdditionalQuestion2Complete { get; init; }
     public string? DisabilityStatus { get; init; }
-    public List<string?> AdditionalQuestions { get; init; } = [];
+    public List<KeyValuePair<int, string>>? AdditionalQuestions { get; init; } = [];
 }

--- a/src/SFA.DAS.CandidateAccount.Application/Application/Commands/UpsertApplication/UpsertApplicationCommandHandler.cs
+++ b/src/SFA.DAS.CandidateAccount.Application/Application/Commands/UpsertApplication/UpsertApplicationCommandHandler.cs
@@ -78,17 +78,19 @@ public class UpsertApplicationCommandHandler(
             return;
         }
 
-        foreach (var additionalQuestion in command.AdditionalQuestions)
-        {
-            await additionalQuestionRepository.UpsertAdditionalQuestion(new AdditionalQuestion
+        if (command.AdditionalQuestions != null)
+            foreach (var newAdditionalQuestion in command.AdditionalQuestions.Select(additionalQuestion => new AdditionalQuestion
+                     {
+                         Id = Guid.NewGuid(),
+                         ApplicationId = application.Id,
+                         CandidateId = command.CandidateId,
+                         QuestionText = additionalQuestion.Value,
+                         QuestionOrder = (short) additionalQuestion.Key,
+                         Answer = string.Empty,
+                     }))
             {
-                Id = Guid.NewGuid(),
-                ApplicationId = application.Id,
-                CandidateId = command.CandidateId,
-                QuestionText = additionalQuestion,
-                Answer = string.Empty,
-            }, command.CandidateId);
-        }
+                await additionalQuestionRepository.UpsertAdditionalQuestion(newAdditionalQuestion, command.CandidateId);
+            }
     }
 
     private async Task RemoveSavedVacancy(Guid candidateId, string vacancyReference)

--- a/src/SFA.DAS.CandidateAccount.Data/AdditionalQuestion/AdditionalQuestionEntityConfiguration.cs
+++ b/src/SFA.DAS.CandidateAccount.Data/AdditionalQuestion/AdditionalQuestionEntityConfiguration.cs
@@ -14,7 +14,7 @@ public class AdditionalQuestionEntityConfiguration : IEntityTypeConfiguration<Ad
         builder.Property(x => x.Id).HasColumnName("Id").HasColumnType("uniqueidentifier").IsRequired();
         builder.Property(x => x.Answer).HasColumnName("Answer").HasColumnType("varchar(max)").IsRequired();
         builder.Property(x => x.QuestionText).HasColumnName("QuestionText").HasColumnType("varchar").HasMaxLength(500).IsRequired();
-        builder.Property(x => x.QuestionOrder).HasColumnName("Order").HasColumnType("int").IsRequired(false);
+        builder.Property(x => x.QuestionOrder).HasColumnName("QuestionOrder").HasColumnType("tinyint").IsRequired(false);
         builder.Property(x => x.ApplicationId).HasColumnName("ApplicationId").HasColumnType("uniqueidentifier").IsRequired();
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Data/AdditionalQuestion/AdditionalQuestionEntityConfiguration.cs
+++ b/src/SFA.DAS.CandidateAccount.Data/AdditionalQuestion/AdditionalQuestionEntityConfiguration.cs
@@ -14,6 +14,7 @@ public class AdditionalQuestionEntityConfiguration : IEntityTypeConfiguration<Ad
         builder.Property(x => x.Id).HasColumnName("Id").HasColumnType("uniqueidentifier").IsRequired();
         builder.Property(x => x.Answer).HasColumnName("Answer").HasColumnType("varchar(max)").IsRequired();
         builder.Property(x => x.QuestionText).HasColumnName("QuestionText").HasColumnType("varchar").HasMaxLength(500).IsRequired();
+        builder.Property(x => x.QuestionOrder).HasColumnName("Order").HasColumnType("int").IsRequired(false);
         builder.Property(x => x.ApplicationId).HasColumnName("ApplicationId").HasColumnType("uniqueidentifier").IsRequired();
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Database/Tables/AdditionalQuestion.sql
+++ b/src/SFA.DAS.CandidateAccount.Database/Tables/AdditionalQuestion.sql
@@ -2,7 +2,8 @@ CREATE TABLE dbo.[AdditionalQuestion] (
     [Id]					uniqueidentifier	NOT NULL,
     [QuestionText]   		nvarchar(500)       NOT NULL,
     [Answer] 			    nvarchar(max)       NULL,
-    [ApplicationId]         uniqueidentifier    NOT NULL
+    [ApplicationId]         uniqueidentifier    NOT NULL,
+    [QuestionOrder]         tinyint             NULL
     CONSTRAINT [PK_AdditionalQuestion] PRIMARY KEY (Id),
     CONSTRAINT [FK_AdditionalQuestion_Application] FOREIGN KEY (ApplicationId) REFERENCES [dbo].[Application](Id),
     INDEX [IX_AdditionalQuestion_ApplicationId] NONCLUSTERED(ApplicationId)

--- a/src/SFA.DAS.CandidateAccount.Domain/Application/AdditionalQuestion.cs
+++ b/src/SFA.DAS.CandidateAccount.Domain/Application/AdditionalQuestion.cs
@@ -7,6 +7,7 @@ public class AdditionalQuestion
     public Guid ApplicationId { get; init; }
     public string? QuestionText { get; init; }
     public string? Answer { get; init; }
+    public short? QuestionOrder { get; init; }
 
     public static implicit operator AdditionalQuestion(AdditionalQuestionEntity source)
     {
@@ -16,6 +17,7 @@ public class AdditionalQuestion
             Answer = source.Answer,
             ApplicationId = source.ApplicationId,
             QuestionText = source.QuestionText,
+            QuestionOrder = source.QuestionOrder,
         };
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Domain/Application/AdditionalQuestionEntity.cs
+++ b/src/SFA.DAS.CandidateAccount.Domain/Application/AdditionalQuestionEntity.cs
@@ -6,6 +6,7 @@
         public required string QuestionText { get; init; }
         public string? Answer { get; set; }
         public Guid ApplicationId { get; init; }
+        public short? QuestionOrder { get; init; }
         public virtual ApplicationEntity ApplicationEntity { get; set; }
 
         public static implicit operator AdditionalQuestionEntity(AdditionalQuestion source)
@@ -15,7 +16,8 @@
                 Answer = source.Answer,
                 QuestionText = source.QuestionText,
                 ApplicationId = source.ApplicationId,
-                Id = source.Id
+                Id = source.Id,
+                QuestionOrder = source.QuestionOrder
             };
         }
     }

--- a/src/SFA.DAS.CandidateAccount.Domain/Application/Application.cs
+++ b/src/SFA.DAS.CandidateAccount.Domain/Application/Application.cs
@@ -1,5 +1,3 @@
-using SFA.DAS.CandidateAccount.Domain.Candidate;
-
 namespace SFA.DAS.CandidateAccount.Domain.Application;
 
 public abstract class ApplicationBase
@@ -124,7 +122,7 @@ public class ApplicationDetail : Application
             ]),
             WhatIsYourInterest = source.WhatIsYourInterest,
             ApplyUnderDisabilityConfidentScheme = source.ApplyUnderDisabilityConfidentScheme,
-            AdditionalQuestions = source.AdditionalQuestionEntities?.Select(c=>(AdditionalQuestion)c).ToList(),
+            AdditionalQuestions = source.AdditionalQuestionEntities?.Select(c=>(AdditionalQuestion)c).OrderBy(ord => ord.QuestionOrder).ToList(),
             Candidate = source.CandidateEntity,
             Qualifications = source.QualificationEntities.OrderBy(c=>c.CreatedDate).Select(c=>(Qualification)c).ToList(),
             WorkHistory = source.WorkHistoryEntities.Select(c=>(WorkHistory)c).ToList(),
@@ -219,7 +217,7 @@ public class Application : ApplicationBase
             ]),
             WhatIsYourInterest = source.WhatIsYourInterest,
             ApplyUnderDisabilityConfidentScheme = source.ApplyUnderDisabilityConfidentScheme,
-            AdditionalQuestions = source.AdditionalQuestionEntities?.Select(c=>(AdditionalQuestion)c).ToList()!,
+            AdditionalQuestions = source.AdditionalQuestionEntities?.Select(c=>(AdditionalQuestion)c).OrderBy(ord => ord.QuestionOrder).ToList()!,
             ResponseNotes = source.ResponseNotes,
             ResponseDate = source.ResponseDate,
             PreviousAnswersSourceId = source.PreviousAnswersSourceId,


### PR DESCRIPTION
Story: https://skillsfundingagency.atlassian.net/browse/FAI-2326

* Change `QuestionOrder` type to `tinyint` in configuration.
* Add `QuestionOrder` column as `tinyint` in SQL table definition.
* Remove unused `using` directive from `Application.cs`.
* Order `AdditionalQuestions` by `QuestionOrder` in `ApplicationDetail`.
* Ensure consistent ordering of `AdditionalQuestions` in `Application`.