### PR TITLE
FAI-3414 Save vacancy functionality not working in FAA

### DIFF
--- a/src/SFA.DAS.CandidateAccount.Api/ApiRequests/SavedVacancyRequest.cs
+++ b/src/SFA.DAS.CandidateAccount.Api/ApiRequests/SavedVacancyRequest.cs
@@ -1,11 +1,9 @@
-﻿using SFA.DAS.Common.Domain.Models;
-
-namespace SFA.DAS.CandidateAccount.Api.ApiRequests
+﻿namespace SFA.DAS.CandidateAccount.Api.ApiRequests
 {
     public class SavedVacancyRequest
     {
-        public VacancyReference? VacancyReference { get; set; }
-        public string? VacancyId { get; set; }
+        public string? VacancyReference { get; set; }
+        public required string VacancyId { get; set; } = null!;
         public DateTime CreatedOn { get; set; }
     }
 }

--- a/src/SFA.DAS.CandidateAccount.Api/Controllers/SavedVacancyController.cs
+++ b/src/SFA.DAS.CandidateAccount.Api/Controllers/SavedVacancyController.cs
@@ -49,16 +49,24 @@ namespace SFA.DAS.CandidateAccount.Api.Controllers
         }
 
         [HttpPut]
-        public async Task<IActionResult> Put(Guid candidateId, SavedVacancyRequest request)
+        public async Task<IActionResult> Put([FromRoute] Guid candidateId, [FromBody] SavedVacancyRequest request)
         {
-            var result = await mediator.Send(new AddSavedVacancyCommand
+            try
             {
-                CandidateId = candidateId,
-                VacancyReference = request.VacancyReference.HasValue ? request.VacancyReference.Value.ToShortString() : string.Empty,
-                VacancyId = request.VacancyId,
-                CreatedOn = request.CreatedOn
-            });
-            return Ok(result.SavedVacancy);
+                var result = await mediator.Send(new AddSavedVacancyCommand
+                {
+                    CandidateId = candidateId,
+                    VacancyReference = request.VacancyReference,
+                    VacancyId = request.VacancyId,
+                    CreatedOn = request.CreatedOn
+                });
+                return Ok(result.SavedVacancy);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Put SavedVacancy : An error occurred");
+                return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
+            }
         }
 
         [HttpDelete("{vacancyId}")]

--- a/src/SFA.DAS.CandidateAccount.Application/Candidate/Commands/AddSavedVacancy/AddSavedVacancyCommand.cs
+++ b/src/SFA.DAS.CandidateAccount.Application/Candidate/Commands/AddSavedVacancy/AddSavedVacancyCommand.cs
@@ -7,8 +7,8 @@ namespace SFA.DAS.CandidateAccount.Application.Candidate.Commands.AddSavedVacanc
     public class AddSavedVacancyCommand : IRequest<AddSavedVacancyCommandResult>
     {
         public Guid CandidateId { get; set; }
-        public string VacancyReference { get; set; }
-        public string VacancyId { get; set; }
+        public string? VacancyReference { get; set; }
+        public required string VacancyId { get; set; }
 
         public DateTime CreatedOn { get; set; }
     }

--- a/src/SFA.DAS.CandidateAccount.Data/SavedVacancy/SavedVacancyRepository.cs
+++ b/src/SFA.DAS.CandidateAccount.Data/SavedVacancy/SavedVacancyRepository.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
 using SFA.DAS.CandidateAccount.Domain.Candidate;
 
 namespace SFA.DAS.CandidateAccount.Data.SavedVacancy


### PR DESCRIPTION
Refactor(controller, request): improve type safety and logging

Updated `SavedVacancyRequest` and `AddSavedVacancyCommand` to use nullable `VacancyReference` and required `VacancyId` for better type safety. Refactored `Put` method in `SavedVacancyController` to include error handling with logging and explicit parameter binding. Removed unused `using` directives and improved namespace formatting.

BREAKING CHANGE: `VacancyId` is now required in `SavedVacancyRequest` and `AddSavedVacancyCommand`.