### PR TITLE
DASD-15391 - Remove das-candidate-account-api variable group

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,6 @@ stages:
   variables:
   - group: MO Management Resources
   - group: MO Shared Resources
-  - group: MO das-candidate-account-api
   jobs:
   - template: pipeline-templates/job/deploy.yml
     parameters:


### PR DESCRIPTION
Removed the variable group for das-candidate-account-api from the deployment pipeline.